### PR TITLE
fix: Update tagpr to v1.7.0 and add required permissions

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -10,8 +10,9 @@ jobs:
       contents: write
       pull-requests: write
       actions: write
+      issues: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: Songmu/tagpr@b84d97fefe5e0a848c01ec7ea59c4ffafc577280 # v1.4.0
+      - uses: Songmu/tagpr@ebb5da052eb05808dd09c92c4ce604d71d8f9233 # v1.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fix tagpr GitHub Action that was failing due to outdated action reference.

## Changes
- Update tagpr from v1.4.0 to v1.7.0
- Add `issues: write` permission (required since v1.5.2)
- Update commit hash to: ebb5da052eb05808dd09c92c4ce604d71d8f9233

## Problem
The previous commit hash was not found, causing the workflow to fail:
```
An action could not be found at the URI https://api.github.com/repos/Songmu/tagpr/tarball/b84d97fefe5e0a848c01ec7ea59c4ffafc577280
```

## References
- Failed run: https://github.com/yuya-takeyama/strict-s3-sync/actions/runs/16700819804
- Latest tagpr release: https://github.com/Songmu/tagpr/releases/tag/v1.7.0