### PR TITLE
fix: Use version tag instead of commit hash for tagpr

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -13,6 +13,6 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: Songmu/tagpr@ebb5da052eb05808dd09c92c4ce604d71d8f9233 # v1.7.0
+      - uses: Songmu/tagpr@v1.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fix tagpr workflow by using version tag instead of commit hash.

## Problem
The tagpr action was failing with:
```
An action could not be found at the URI https://api.github.com/repos/Songmu/tagpr/tarball/ebb5da052eb05808dd09c92c4ce604d71d8f9233
```

## Solution
Use the version tag `v1.7.0` directly instead of the commit hash. This is more reliable as GitHub can always resolve version tags.

## Changes
- Change `Songmu/tagpr@ebb5da052eb05808dd09c92c4ce604d71d8f9233` to `Songmu/tagpr@v1.7.0`

## Related
- Failed runs: #16700819804, #16700880434
- Previous PR: #13