### PR TITLE
fix: Update tagpr workflow to match official documentation

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -9,10 +9,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: write
       issues: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: Songmu/tagpr@v1.7.0
+        with:
+          persist-credentials: true
+      - uses: Songmu/tagpr@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fix tagpr workflow by following the official documentation exactly.

## Changes
- Add `persist-credentials: true` to checkout action (required for tagpr)
- Use `@v1` tag as recommended in official docs
- Remove unnecessary `actions: write` permission

## Problem
The tagpr action was failing with commit hash not found error.

## Solution
Follow the official example from https://github.com/Songmu/tagpr exactly:
- Use version tag `@v1` instead of specific version
- Add `persist-credentials: true` to checkout

## Reference
Official documentation: https://github.com/Songmu/tagpr#usage