### PR TITLE
fix: Update release workflow tag pattern to match semver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Fix release workflow to only trigger on proper semver tags.

## Problem
The current pattern `v*` is too broad and could trigger on:
- Pre-release tags like `v0.0.0-1`
- Invalid tags like `vtest`
- Any tag starting with "v"

## Solution
Change the pattern to `v[0-9]+.[0-9]+.[0-9]+` which matches:
- ✅ `v0.0.1`
- ✅ `v1.0.0`
- ✅ `v10.20.30`
- ❌ `v0.0.0-1` (pre-release)
- ❌ `vtest` (invalid)

This ensures the release workflow only runs for stable semver releases.

## Testing
After merging, the workflow will trigger when tagpr creates tags like `v0.1.0` but not for pre-release tags.