### PR TITLE
feat(workflows): use GitHub App authentication for tagpr

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -13,8 +13,6 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          persist-credentials: true
       
       - name: Generate GitHub App token
         id: generate_token

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   tagpr:
     runs-on: ubuntu-latest
+    environment: main
     permissions:
       contents: write
       pull-requests: write
@@ -14,6 +15,14 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: true
+      
+      - name: Generate GitHub App token
+        id: generate_token
+        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v1.9.0
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      
       - uses: Songmu/tagpr@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
## Summary
- tagpr ワークフローで GitHub App を使用するように変更
- これによりタグ作成時に release ワークフローがトリガーされるようになる

## Test plan
- [ ] tagpr が正常に動作すること
- [ ] タグが作成された際に release ワークフローがトリガーされること