### PR TITLE
chore(deps): pin Songmu/tagpr action to v1.7.0

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -21,6 +21,6 @@ jobs:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       
-      - uses: Songmu/tagpr@v1
+      - uses: Songmu/tagpr@ebb5da0cccdb47c533d4b520ebc0acd475b16614 # v1.7.0
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
## Summary
- Pin Songmu/tagpr GitHub Action to a specific commit SHA (v1.7.0)
- This improves security by ensuring the action version cannot be changed without explicit update

## Test plan
- [ ] Verify tagpr workflow continues to work correctly after pinning
- [ ] Confirm the pinned SHA corresponds to the expected v1.7.0 release

🤖 Generated with [Claude Code](https://claude.ai/code)