### PR TITLE
feat(workflows): enable manual release workflow triggering

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ name: release
 on:
   push:
     tags: [v*]
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` event to release workflow to enable manual triggering
- This provides a workaround when automatic tag push events do not properly trigger the workflow

## Test plan
- [ ] Merge this PR
- [ ] Navigate to Actions tab → release workflow
- [ ] Click "Run workflow" button
- [ ] Verify the workflow can be manually triggered

🤖 Generated with [Claude Code](https://claude.ai/code)