### PR TITLE
fix: remove invalid toolchain directive from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/yuya-takeyama/strict-s3-sync
 
 go 1.22
 
-toolchain go1.24.4
-
 require (
 	github.com/aws/aws-sdk-go-v2 v1.37.1
 	github.com/aws/aws-sdk-go-v2/config v1.30.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yuya-takeyama/strict-s3-sync
 
-go 1.22
+go 1.24
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.37.1


### PR DESCRIPTION
## Summary
- Remove invalid `toolchain go1.24.4` directive that was causing GitHub Actions builds to fail
- Update Go version from 1.22 to 1.24 in go.mod

## Test plan
- [ ] GitHub Actions should pass after this fix
- [ ] Local `go build` should work without errors