### PR TITLE
chore: add third_party_licenses to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ CLAUDE.local.json
 # Build output
 /super-s3-sync
 /strict-s3-sync
+third_party_licenses
 
 # Temporary files
 tmp/


### PR DESCRIPTION
## Summary
- Add `third_party_licenses` to .gitignore as it is generated during the build process
- This file should not be committed to the repository

## Test plan
- [ ] Verify that third_party_licenses file is ignored by git
- [ ] Ensure build process continues to work correctly