### PR TITLE
feat: add syft for SBOM generation

### DIFF
--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -26,6 +26,31 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/anchore/syft/v1.29.1/syft_1.29.1_darwin_amd64.tar.gz",
+      "checksum": "A8B6F82AFDAC8E0DF8F34AFFC05ACE17DA2FF4D9B9F56AC4231DD6AA50D282B2",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/anchore/syft/v1.29.1/syft_1.29.1_darwin_arm64.tar.gz",
+      "checksum": "577018D66C93780B0E92EC8CA9F11F9B9EA98A364036F5BC29DA6E51C81F1CD2",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/anchore/syft/v1.29.1/syft_1.29.1_linux_amd64.tar.gz",
+      "checksum": "CA704907E5A7B697C6E683832CA128E2AE60DE63D7D87F3E2E39672DF9038FA4",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/anchore/syft/v1.29.1/syft_1.29.1_linux_arm64.tar.gz",
+      "checksum": "D8ABA89EEF3F9A80A650B608366C7E0E284763D59C54D2AC0808DEC27BC1CBC4",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/anchore/syft/v1.29.1/syft_1.29.1_windows_amd64.zip",
+      "checksum": "3C67CD9AF40CDCC7FFCE041C8349B4A77F33810184820C05DF23440C8E0AA1D7",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/cli/cli/v2.76.0/gh_2.76.0_linux_amd64.tar.gz",
       "checksum": "BC46A0F43FA357CDFCFFC77F92A48303F5BACD97CF3E59A807DA2682CA4126DA",
       "algorithm": "sha256"

--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -1,6 +1,31 @@
 {
   "checksums": [
     {
+      "id": "github_release/github.com/anchore/syft/v1.20.0/syft_1.20.0_darwin_amd64.tar.gz",
+      "checksum": "5FDF7AFD0F1BFDBB2A1A575EACEF8E10EDFCB4783631BAAA7572A9F4A4D86441",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/anchore/syft/v1.20.0/syft_1.20.0_darwin_arm64.tar.gz",
+      "checksum": "91365712A06AF0C0DCD06F5E87FC8791C4332831B3DD6F5474ACAAF803D71D82",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/anchore/syft/v1.20.0/syft_1.20.0_linux_amd64.tar.gz",
+      "checksum": "689E12C5CBF67521CE61B9C126068F9EAABE1223E77971B2FEDE50033FF6B5CC",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/anchore/syft/v1.20.0/syft_1.20.0_linux_arm64.tar.gz",
+      "checksum": "53F76737DDBF425C89240D5B0BE0990B1A71E66890B44F19743221B17E6EE635",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/anchore/syft/v1.20.0/syft_1.20.0_windows_amd64.zip",
+      "checksum": "B8BFDEDB261DE2A69768097422A73BC72273EE92136FF676A20C3161E658881F",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/cli/cli/v2.76.0/gh_2.76.0_linux_amd64.tar.gz",
       "checksum": "BC46A0F43FA357CDFCFFC77F92A48303F5BACD97CF3E59A807DA2682CA4126DA",
       "algorithm": "sha256"

--- a/aqua/aqua.yaml
+++ b/aqua/aqua.yaml
@@ -16,3 +16,4 @@ packages:
   - name: sigstore/cosign@v2.5.3
   - name: google/go-licenses@v1.6.0
   - name: goreleaser/goreleaser@v2.11.1
+  - name: anchore/syft@v1.20.0

--- a/aqua/aqua.yaml
+++ b/aqua/aqua.yaml
@@ -16,4 +16,4 @@ packages:
   - name: sigstore/cosign@v2.5.3
   - name: google/go-licenses@v1.6.0
   - name: goreleaser/goreleaser@v2.11.1
-  - name: anchore/syft@v1.20.0
+  - name: anchore/syft@v1.29.1


### PR DESCRIPTION
## Summary
- Add anchore/syft@v1.29.1 (latest version) to aqua packages for Software Bill of Materials (SBOM) generation
- This tool is required by the existing .goreleaser.yml configuration that generates SBOM files during releases

## Changes
- Add syft to aqua.yaml packages list
- Update aqua-checksums.json with syft checksums

## Test plan
- [ ] Verify syft is installed correctly with `aqua i`
- [ ] Confirm `syft --version` shows v1.29.1
- [ ] Check that release process generates SBOM files correctly