### PR TITLE
Fix CI errors and update dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           aqua_version: v2.43.1
           working_directory: aqua
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Get dependencies
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,7 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
@@ -76,17 +76,17 @@ release:
   mode: append
   footer: |
     ## Installation
-    
+
     ### Using aqua
     ```bash
     aqua g -i yuya-takeyama/strict-s3-sync
     ```
-    
+
     ### Using go install
     ```bash
     go install github.com/yuya-takeyama/strict-s3-sync/cmd/strict-s3-sync@latest
     ```
-    
+
     ### Binary download
     Download the appropriate binary for your platform from the assets below.
 

--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -1,31 +1,6 @@
 {
   "checksums": [
     {
-      "id": "github_release/github.com/anchore/syft/v1.20.0/syft_1.20.0_darwin_amd64.tar.gz",
-      "checksum": "5FDF7AFD0F1BFDBB2A1A575EACEF8E10EDFCB4783631BAAA7572A9F4A4D86441",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/anchore/syft/v1.20.0/syft_1.20.0_darwin_arm64.tar.gz",
-      "checksum": "91365712A06AF0C0DCD06F5E87FC8791C4332831B3DD6F5474ACAAF803D71D82",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/anchore/syft/v1.20.0/syft_1.20.0_linux_amd64.tar.gz",
-      "checksum": "689E12C5CBF67521CE61B9C126068F9EAABE1223E77971B2FEDE50033FF6B5CC",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/anchore/syft/v1.20.0/syft_1.20.0_linux_arm64.tar.gz",
-      "checksum": "53F76737DDBF425C89240D5B0BE0990B1A71E66890B44F19743221B17E6EE635",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/anchore/syft/v1.20.0/syft_1.20.0_windows_amd64.zip",
-      "checksum": "B8BFDEDB261DE2A69768097422A73BC72273EE92136FF676A20C3161E658881F",
-      "algorithm": "sha256"
-    },
-    {
       "id": "github_release/github.com/anchore/syft/v1.29.1/syft_1.29.1_darwin_amd64.tar.gz",
       "checksum": "A8B6F82AFDAC8E0DF8F34AFFC05ACE17DA2FF4D9B9F56AC4231DD6AA50D282B2",
       "algorithm": "sha256"


### PR DESCRIPTION
## Summary
- Update aqua checksums after running `aqua upc --prune`
- Fix GoReleaser deprecated configuration (format -> formats)
- Add GITHUB_TOKEN to aqua-installer to avoid rate limit issues

## Related issues
- Release workflow error: https://github.com/yuya-takeyama/strict-s3-sync/actions/runs/16702947675/job/47276815812
- Test workflow error: https://github.com/yuya-takeyama/strict-s3-sync/actions/runs/16702947675/job/47276978264

## Changes
1. Updated aqua checksums to remove old syft v1.20.0 entries
2. Changed GoReleaser `format_overrides.format` to `format_overrides.formats` as per deprecation notice
3. Added GITHUB_TOKEN environment variable to aqua-installer step to prevent rate limiting