### PR TITLE
Remove cosign configuration for go-release-workflow v6.0.0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,20 +48,6 @@ checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
   algorithm: sha256
 
-signs:
-  - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
-    certificate: "${artifact}.pem"
-    args:
-      - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
-      - "${artifact}"
-      - "--yes"
-    artifacts: checksum
-    output: true
-
 sboms:
   - artifacts: archive
     documents:


### PR DESCRIPTION
## Summary
Remove cosign configuration from .goreleaser.yml to comply with go-release-workflow v6.0.0 breaking changes.

## Background
go-release-workflow v6.0.0 introduced a security enhancement by splitting the build and sign jobs to follow SLSA security requirements. This prevents potential unauthorized access to signing keys during the build process.

## Changes
- Removed the `signs` section from .goreleaser.yml
- Cosign signing is now handled by the workflow itself instead of GoReleaser

## Reference
- https://github.com/suzuki-shunsuke/go-release-workflow/releases/tag/v6.0.0