### PR TITLE
feat: add --result-json-file option for programmatic result processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,19 +98,18 @@ When using `--result-json-file`, the tool outputs a structured JSON report:
 {
   "changes": [
     {
-      "from": "/Users/yuya/project/file1.txt",
-      "to": "s3://my-bucket/prefix/file1.txt",
-      "action": "create"
+      "action": "create",
+      "source": "/Users/yuya/project/file1.txt",
+      "target": "s3://my-bucket/prefix/file1.txt"
     },
     {
-      "from": "/Users/yuya/project/file2.txt",
-      "to": "s3://my-bucket/prefix/file2.txt",
-      "action": "update"
+      "action": "update",
+      "source": "/Users/yuya/project/file2.txt",
+      "target": "s3://my-bucket/prefix/file2.txt"
     },
     {
-      "from": "s3://my-bucket/prefix/old-file.txt",
-      "to": "",
-      "action": "delete"
+      "action": "delete",
+      "target": "s3://my-bucket/prefix/old-file.txt"
     }
   ],
   "summary": {

--- a/cmd/strict-s3-sync/main.go
+++ b/cmd/strict-s3-sync/main.go
@@ -42,9 +42,9 @@ type SyncResult struct {
 }
 
 type FileChange struct {
-	From   string `json:"from"`
-	To     string `json:"to"`
 	Action string `json:"action"`
+	Source string `json:"source,omitempty"`
+	Target string `json:"target"`
 	Error  string `json:"error,omitempty"`
 }
 
@@ -160,9 +160,9 @@ func run(cmd *cobra.Command, args []string) error {
 				syncLogger.Upload(item.LocalPath, fmt.Sprintf("s3://%s/%s", item.Bucket, item.Key))
 				action := getUploadActionName(item.Reason)
 				change := FileChange{
-					From:   getAbsolutePath(item.LocalPath),
-					To:     formatS3Path(item.Bucket, item.Key),
 					Action: action,
+					Source: getAbsolutePath(item.LocalPath),
+					Target: formatS3Path(item.Bucket, item.Key),
 				}
 				syncResult.Changes = append(syncResult.Changes, change)
 				if action == "create" {
@@ -173,9 +173,8 @@ func run(cmd *cobra.Command, args []string) error {
 			case planner.ActionDelete:
 				syncLogger.Delete(fmt.Sprintf("s3://%s/%s", item.Bucket, item.Key))
 				change := FileChange{
-					From:   formatS3Path(item.Bucket, item.Key),
-					To:     "", // deleted
 					Action: "delete",
+					Target: formatS3Path(item.Bucket, item.Key),
 				}
 				syncResult.Changes = append(syncResult.Changes, change)
 				syncResult.Summary.Deleted++
@@ -206,16 +205,15 @@ func run(cmd *cobra.Command, args []string) error {
 			}
 			if result.Item.Action == planner.ActionUpload {
 				change = FileChange{
-					From:   getAbsolutePath(result.Item.LocalPath),
-					To:     formatS3Path(result.Item.Bucket, result.Item.Key),
 					Action: action,
+					Source: getAbsolutePath(result.Item.LocalPath),
+					Target: formatS3Path(result.Item.Bucket, result.Item.Key),
 					Error:  result.Error.Error(),
 				}
 			} else {
 				change = FileChange{
-					From:   formatS3Path(result.Item.Bucket, result.Item.Key),
-					To:     "", // deleted
 					Action: action,
+					Target: formatS3Path(result.Item.Bucket, result.Item.Key),
 					Error:  result.Error.Error(),
 				}
 			}
@@ -227,15 +225,14 @@ func run(cmd *cobra.Command, args []string) error {
 			}
 			if result.Item.Action == planner.ActionUpload {
 				change = FileChange{
-					From:   getAbsolutePath(result.Item.LocalPath),
-					To:     formatS3Path(result.Item.Bucket, result.Item.Key),
 					Action: action,
+					Source: getAbsolutePath(result.Item.LocalPath),
+					Target: formatS3Path(result.Item.Bucket, result.Item.Key),
 				}
 			} else {
 				change = FileChange{
-					From:   formatS3Path(result.Item.Bucket, result.Item.Key),
-					To:     "", // deleted
 					Action: action,
+					Target: formatS3Path(result.Item.Bucket, result.Item.Key),
 				}
 			}
 			switch result.Item.Action {


### PR DESCRIPTION
## Summary

- Added `--result-json-file` option to output sync results as JSON
- Distinguish between create and update actions based on file reason  
- Support for both dry-run and actual execution modes

## Motivation

Closes #2

This feature enables CI/CD pipelines to programmatically determine which files have changed during sync operations. The JSON output can be used to:
- Trigger CloudFront cache invalidation for changed files only
- Generate deployment reports
- Make automated deployment decisions

## Changes

1. **New CLI option**: `--result-json-file <path>` 
2. **JSON output structure**:
   - `changes`: Array of file change details
   - `summary`: Statistics (created, updated, deleted, failed)
3. **Action types**: Properly distinguish between `create` and `update` based on the sync reason

## JSON Output Format

### Create/Update Operations
```json
{
  "action": "create",
  "source": "/path/to/local/file.txt",
  "target": "s3://bucket/prefix/file.txt"
}
```

### Delete Operations
```json
{
  "action": "delete",
  "target": "s3://bucket/prefix/file.txt"
}
```

### Complete Example
```json
{
  "changes": [
    {
      "action": "create",
      "source": "/Users/yuya/project/file1.txt",
      "target": "s3://my-bucket/prefix/file1.txt"
    },
    {
      "action": "update",
      "source": "/Users/yuya/project/file2.txt",
      "target": "s3://my-bucket/prefix/file2.txt"
    },
    {
      "action": "delete",
      "target": "s3://my-bucket/prefix/old-file.txt"
    }
  ],
  "summary": {
    "total_files": 3,
    "created": 1,
    "updated": 1,
    "deleted": 1,
    "failed": 0
  }
}
```

## Breaking Changes

⚠️ **This PR includes breaking changes to the JSON output format:**

1. Changed from `from`/`to` to `source`/`target` pattern
2. Delete operations now only have `target` field (no `source`)
3. Removed unused `skip` field from summary

This structure provides clearer semantics and enables future extensibility for S3-to-local and S3-to-S3 sync operations.

## Test Plan

- [x] Test dry-run mode with JSON output
- [x] Test actual sync with JSON output
- [x] Verify create vs update distinction
- [x] Test with various sync scenarios (create, update, delete)
- [x] Verify JSON file is created with proper permissions (0644)
- [ ] Test error handling and failed operations in JSON output

🤖 Generated with [Claude Code](https://claude.ai/code)