### PR TITLE
feat: implement parallel file system traversal (not merged)

### DIFF
--- a/pkg/planner/fs_to_s3_parallel.go
+++ b/pkg/planner/fs_to_s3_parallel.go
@@ -1,0 +1,139 @@
+package planner
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+)
+
+// parallelGatherLocalFiles implements parallel file system traversal using worker pool pattern
+func (p *FSToS3Planner) parallelGatherLocalFiles(basePath string, excludes []string) ([]ItemMetadata, error) {
+	// ワーカー数の設定（デフォルト8、最大32）
+	workerCount := 8
+	if envWorkers := os.Getenv("STRICT_S3_SYNC_WORKERS"); envWorkers != "" {
+		if count, err := strconv.Atoi(envWorkers); err == nil && count > 0 {
+			workerCount = count
+			if workerCount > 32 {
+				workerCount = 32
+			}
+		}
+	}
+
+	type dirTask struct {
+		path string
+	}
+
+	// チャンネルの作成
+	dirQueue := make(chan dirTask, 1000)
+
+	// 結果の収集
+	var items []ItemMetadata
+	var itemsMutex sync.Mutex
+	var resultErr error
+	var errOnce sync.Once
+
+	// ディレクトリ処理の待機グループ
+	var dirWg sync.WaitGroup
+
+	// ワーカープール
+	var workerWg sync.WaitGroup
+	workerWg.Add(workerCount)
+
+	for i := 0; i < workerCount; i++ {
+		go func() {
+			defer workerWg.Done()
+
+			for task := range dirQueue {
+				entries, err := os.ReadDir(task.path)
+				if err != nil {
+					// アクセス権限エラーなどは警告として扱い、処理を継続
+					if !os.IsPermission(err) {
+						errOnce.Do(func() {
+							resultErr = err
+						})
+					}
+					dirWg.Done() // このディレクトリの処理完了
+					continue
+				}
+
+				for _, entry := range entries {
+					fullPath := filepath.Join(task.path, entry.Name())
+
+					if entry.IsDir() {
+						// 新しいディレクトリを発見
+						dirWg.Add(1)
+
+						// ノンブロッキングで送信を試みる
+						select {
+						case dirQueue <- dirTask{path: fullPath}:
+							// 成功
+						default:
+							// キューが満杯の場合はブロッキング送信
+							go func(path string) {
+								dirQueue <- dirTask{path: path}
+							}(fullPath)
+						}
+						continue
+					}
+
+					// ファイルの処理
+					info, err := entry.Info()
+					if err != nil {
+						continue
+					}
+
+					relPath, err := filepath.Rel(basePath, fullPath)
+					if err != nil {
+						continue
+					}
+
+					relPath = filepath.ToSlash(relPath)
+
+					excluded, err := IsExcluded(relPath, excludes)
+					if err != nil {
+						continue
+					}
+					if excluded {
+						continue
+					}
+
+					itemsMutex.Lock()
+					items = append(items, ItemMetadata{
+						Path:    relPath,
+						Size:    info.Size(),
+						ModTime: info.ModTime(),
+					})
+					itemsMutex.Unlock()
+				}
+
+				dirWg.Done() // このディレクトリの処理完了
+			}
+		}()
+	}
+
+	// 初期ディレクトリを追加
+	dirWg.Add(1)
+	dirQueue <- dirTask{path: basePath}
+
+	// 全てのディレクトリの処理が完了するまで待機
+	go func() {
+		dirWg.Wait()
+		close(dirQueue)
+	}()
+
+	// ワーカーの完了を待つ
+	workerWg.Wait()
+
+	if resultErr != nil {
+		return nil, resultErr
+	}
+
+	// 結果をパスでソート
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Path < items[j].Path
+	})
+
+	return items, nil
+}

--- a/pkg/planner/parallel_gather_bench_test.go
+++ b/pkg/planner/parallel_gather_bench_test.go
@@ -1,0 +1,213 @@
+package planner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yuya-takeyama/strict-s3-sync/pkg/logger"
+)
+
+// ベンチマーク用のディレクトリ構造を作成
+func createBenchmarkDirTree(b *testing.B, tmpDir string, numDirs, filesPerDir int) {
+	b.Helper()
+
+	// ディレクトリとファイルを作成
+	for i := 0; i < numDirs; i++ {
+		dirPath := filepath.Join(tmpDir, fmt.Sprintf("dir%03d", i))
+		if err := os.MkdirAll(dirPath, 0755); err != nil {
+			b.Fatalf("Failed to create directory: %v", err)
+		}
+
+		// 各ディレクトリにファイルを作成
+		for j := 0; j < filesPerDir; j++ {
+			filePath := filepath.Join(dirPath, fmt.Sprintf("file%03d.txt", j))
+			content := fmt.Sprintf("This is file %d in directory %d", j, i)
+			if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+				b.Fatalf("Failed to create file: %v", err)
+			}
+		}
+
+		// ネストしたディレクトリも作成
+		subDirPath := filepath.Join(dirPath, "subdir")
+		if err := os.MkdirAll(subDirPath, 0755); err != nil {
+			b.Fatalf("Failed to create subdirectory: %v", err)
+		}
+
+		// サブディレクトリにもファイルを作成
+		for j := 0; j < filesPerDir/2; j++ {
+			filePath := filepath.Join(subDirPath, fmt.Sprintf("subfile%03d.txt", j))
+			content := fmt.Sprintf("This is subfile %d in directory %d", j, i)
+			if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+				b.Fatalf("Failed to create subfile: %v", err)
+			}
+		}
+	}
+}
+
+// 順次版の実装（比較用）
+func sequentialGatherLocalFiles(basePath string, excludes []string) ([]ItemMetadata, error) {
+	var items []ItemMetadata
+
+	err := filepath.Walk(basePath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(basePath, path)
+		if err != nil {
+			return err
+		}
+
+		relPath = filepath.ToSlash(relPath)
+
+		excluded, err := IsExcluded(relPath, excludes)
+		if err != nil {
+			return err
+		}
+		if excluded {
+			return nil
+		}
+
+		items = append(items, ItemMetadata{
+			Path:    relPath,
+			Size:    info.Size(),
+			ModTime: info.ModTime(),
+		})
+
+		return nil
+	})
+
+	return items, err
+}
+
+// ベンチマーク: 小規模ディレクトリ構造
+func BenchmarkGatherLocalFiles_Small(b *testing.B) {
+	tmpDir := b.TempDir()
+	createBenchmarkDirTree(b, tmpDir, 10, 20) // 10 dirs × 20 files = 200 files + subdirs
+
+	planner := &FSToS3Planner{
+		client: nil,
+		logger: &logger.SyncLogger{IsDryRun: false, IsQuiet: true},
+	}
+
+	b.Run("Sequential", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := sequentialGatherLocalFiles(tmpDir, []string{})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Parallel", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := planner.parallelGatherLocalFiles(tmpDir, []string{})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// ベンチマーク: 中規模ディレクトリ構造
+func BenchmarkGatherLocalFiles_Medium(b *testing.B) {
+	tmpDir := b.TempDir()
+	createBenchmarkDirTree(b, tmpDir, 50, 50) // 50 dirs × 50 files = 2500 files + subdirs
+
+	planner := &FSToS3Planner{
+		client: nil,
+		logger: &logger.SyncLogger{IsDryRun: false, IsQuiet: true},
+	}
+
+	b.Run("Sequential", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := sequentialGatherLocalFiles(tmpDir, []string{})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Parallel", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := planner.parallelGatherLocalFiles(tmpDir, []string{})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// ベンチマーク: 大規模ディレクトリ構造
+func BenchmarkGatherLocalFiles_Large(b *testing.B) {
+	if testing.Short() {
+		b.Skip("Skipping large benchmark in short mode")
+	}
+
+	tmpDir := b.TempDir()
+	createBenchmarkDirTree(b, tmpDir, 100, 100) // 100 dirs × 100 files = 10000 files + subdirs
+
+	planner := &FSToS3Planner{
+		client: nil,
+		logger: &logger.SyncLogger{IsDryRun: false, IsQuiet: true},
+	}
+
+	b.Run("Sequential", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := sequentialGatherLocalFiles(tmpDir, []string{})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Parallel", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := planner.parallelGatherLocalFiles(tmpDir, []string{})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// ワーカー数による性能比較
+func BenchmarkGatherLocalFiles_WorkerComparison(b *testing.B) {
+	tmpDir := b.TempDir()
+	createBenchmarkDirTree(b, tmpDir, 50, 50)
+
+	workerCounts := []int{1, 2, 4, 8, 16, 32}
+
+	for _, workers := range workerCounts {
+		b.Run(fmt.Sprintf("Workers_%d", workers), func(b *testing.B) {
+			// 環境変数を設定してワーカー数を制御
+			os.Setenv("STRICT_S3_SYNC_WORKERS", fmt.Sprintf("%d", workers))
+			defer os.Unsetenv("STRICT_S3_SYNC_WORKERS")
+
+			planner := &FSToS3Planner{
+				client: nil,
+				logger: &logger.SyncLogger{IsDryRun: false, IsQuiet: true},
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := planner.parallelGatherLocalFiles(tmpDir, []string{})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/planner/parallel_gather_test.go
+++ b/pkg/planner/parallel_gather_test.go
@@ -1,0 +1,277 @@
+package planner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yuya-takeyama/strict-s3-sync/pkg/logger"
+)
+
+func TestParallelGatherLocalFiles(t *testing.T) {
+	// テスト用の一時ディレクトリを作成
+	tmpDir := t.TempDir()
+
+	// テストファイル構造を作成
+	testFiles := []struct {
+		path    string
+		isDir   bool
+		content string
+	}{
+		{"file1.txt", false, "content1"},
+		{"file2.txt", false, "content2"},
+		{"dir1", true, ""},
+		{"dir1/file3.txt", false, "content3"},
+		{"dir1/file4.txt", false, "content4"},
+		{"dir1/subdir", true, ""},
+		{"dir1/subdir/file5.txt", false, "content5"},
+		{"dir2", true, ""},
+		{"dir2/file6.txt", false, "content6"},
+		{".hidden", false, "hidden"},
+		{"dir1/.gitignore", false, "ignored"},
+	}
+
+	for _, tf := range testFiles {
+		path := filepath.Join(tmpDir, tf.path)
+		if tf.isDir {
+			if err := os.MkdirAll(path, 0755); err != nil {
+				t.Fatalf("Failed to create directory %s: %v", path, err)
+			}
+		} else {
+			dir := filepath.Dir(path)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				t.Fatalf("Failed to create parent directory %s: %v", dir, err)
+			}
+			if err := os.WriteFile(path, []byte(tf.content), 0644); err != nil {
+				t.Fatalf("Failed to create file %s: %v", path, err)
+			}
+		}
+	}
+
+	// FSToS3Planner を作成
+	planner := &FSToS3Planner{
+		client: nil, // このテストではS3クライアントは使わない
+		logger: &logger.SyncLogger{IsDryRun: false, IsQuiet: true},
+	}
+
+	tests := []struct {
+		name         string
+		excludes     []string
+		wantFiles    []string
+		wantExcluded []string
+	}{
+		{
+			name:     "no excludes",
+			excludes: []string{},
+			wantFiles: []string{
+				".hidden",
+				"dir1/.gitignore",
+				"dir1/file3.txt",
+				"dir1/file4.txt",
+				"dir1/subdir/file5.txt",
+				"dir2/file6.txt",
+				"file1.txt",
+				"file2.txt",
+			},
+			wantExcluded: []string{},
+		},
+		{
+			name:     "exclude hidden files",
+			excludes: []string{".*", "**/.*"},
+			wantFiles: []string{
+				"dir1/file3.txt",
+				"dir1/file4.txt",
+				"dir1/subdir/file5.txt",
+				"dir2/file6.txt",
+				"file1.txt",
+				"file2.txt",
+			},
+			wantExcluded: []string{".hidden", "dir1/.gitignore"},
+		},
+		{
+			name:     "exclude specific directory",
+			excludes: []string{"dir1/**"},
+			wantFiles: []string{
+				".hidden",
+				"dir2/file6.txt",
+				"file1.txt",
+				"file2.txt",
+			},
+			wantExcluded: []string{
+				"dir1/.gitignore",
+				"dir1/file3.txt",
+				"dir1/file4.txt",
+				"dir1/subdir/file5.txt",
+			},
+		},
+		{
+			name:     "exclude by pattern",
+			excludes: []string{"**/*.txt"},
+			wantFiles: []string{
+				".hidden",
+				"dir1/.gitignore",
+			},
+			wantExcluded: []string{
+				"dir1/file3.txt",
+				"dir1/file4.txt",
+				"dir1/subdir/file5.txt",
+				"dir2/file6.txt",
+				"file1.txt",
+				"file2.txt",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 並列版のgatherLocalFilesを実行
+			items, err := planner.parallelGatherLocalFiles(tmpDir, tt.excludes)
+			if err != nil {
+				t.Fatalf("parallelGatherLocalFiles failed: %v", err)
+			}
+
+			// 取得したファイルのパスを抽出
+			gotPaths := make([]string, len(items))
+			for i, item := range items {
+				gotPaths[i] = item.Path
+			}
+
+			// 期待するファイル数と一致するか確認
+			if len(gotPaths) != len(tt.wantFiles) {
+				t.Errorf("Got %d files, want %d files", len(gotPaths), len(tt.wantFiles))
+				t.Errorf("Got: %v", gotPaths)
+				t.Errorf("Want: %v", tt.wantFiles)
+			}
+
+			// 各ファイルが期待通りか確認
+			for i, wantPath := range tt.wantFiles {
+				if i >= len(gotPaths) {
+					t.Errorf("Missing file: %s", wantPath)
+					continue
+				}
+				if gotPaths[i] != wantPath {
+					t.Errorf("File %d: got %s, want %s", i, gotPaths[i], wantPath)
+				}
+			}
+
+			// ファイルのメタデータが正しく設定されているか確認
+			for _, item := range items {
+				if item.Size == 0 && item.Path != ".hidden" { // .hidden は空の可能性がある
+					// サイズが0のファイルは内容が空でない限りエラー
+					fullPath := filepath.Join(tmpDir, item.Path)
+					content, _ := os.ReadFile(fullPath)
+					if len(content) > 0 {
+						t.Errorf("File %s has size 0 but contains content", item.Path)
+					}
+				}
+				if item.ModTime.IsZero() {
+					t.Errorf("File %s has zero ModTime", item.Path)
+				}
+			}
+		})
+	}
+}
+
+// 並列版と順次版の結果が一致することを確認するテスト
+func TestParallelGatherLocalFilesConsistency(t *testing.T) {
+	// テスト用の一時ディレクトリを作成
+	tmpDir := t.TempDir()
+
+	// より複雑なディレクトリ構造を作成
+	dirs := []string{
+		"a/b/c/d",
+		"a/b/e",
+		"f/g/h",
+		"i",
+	}
+
+	for _, dir := range dirs {
+		path := filepath.Join(tmpDir, dir)
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatalf("Failed to create directory %s: %v", path, err)
+		}
+		// 各ディレクトリに複数のファイルを作成
+		for i := 0; i < 3; i++ {
+			filename := filepath.Join(path, "file"+string(rune('a'+i))+".txt")
+			content := "content of " + filename
+			if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
+				t.Fatalf("Failed to create file %s: %v", filename, err)
+			}
+		}
+	}
+
+	planner := &FSToS3Planner{
+		client: nil,
+		logger: &logger.SyncLogger{IsDryRun: false, IsQuiet: true},
+	}
+
+	// 順次版の実装（比較用）
+	sequentialGather := func(basePath string, excludes []string) ([]ItemMetadata, error) {
+		var items []ItemMetadata
+		err := filepath.Walk(basePath, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+			relPath, err := filepath.Rel(basePath, path)
+			if err != nil {
+				return err
+			}
+			relPath = filepath.ToSlash(relPath)
+			excluded, err := IsExcluded(relPath, excludes)
+			if err != nil {
+				return err
+			}
+			if excluded {
+				return nil
+			}
+			items = append(items, ItemMetadata{
+				Path:    relPath,
+				Size:    info.Size(),
+				ModTime: info.ModTime(),
+			})
+			return nil
+		})
+		return items, err
+	}
+
+	// 両方の実装を実行
+	seqItems, err := sequentialGather(tmpDir, []string{})
+	if err != nil {
+		t.Fatalf("Sequential gather failed: %v", err)
+	}
+
+	parItems, err := planner.parallelGatherLocalFiles(tmpDir, []string{})
+	if err != nil {
+		t.Fatalf("Parallel gather failed: %v", err)
+	}
+
+	// 結果が同じ数のファイルを含むか確認
+	if len(seqItems) != len(parItems) {
+		t.Errorf("Different number of files: sequential=%d, parallel=%d", len(seqItems), len(parItems))
+	}
+
+	// パスでソート（両方とも同じ順序になるはず）
+	seqPaths := make([]string, len(seqItems))
+	for i, item := range seqItems {
+		seqPaths[i] = item.Path
+	}
+
+	parPaths := make([]string, len(parItems))
+	for i, item := range parItems {
+		parPaths[i] = item.Path
+	}
+
+	// 同じファイルが含まれているか確認
+	for i := range seqPaths {
+		if i >= len(parPaths) {
+			t.Errorf("Parallel missing file: %s", seqPaths[i])
+			continue
+		}
+		if seqPaths[i] != parPaths[i] {
+			t.Errorf("Mismatch at index %d: sequential=%s, parallel=%s", i, seqPaths[i], parPaths[i])
+		}
+	}
+}

--- a/pkg/planner/pattern_test.go
+++ b/pkg/planner/pattern_test.go
@@ -1,0 +1,56 @@
+package planner
+
+import "testing"
+
+func TestIsExcludedPatterns(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		patterns []string
+		want     bool
+	}{
+		{
+			name:     "hidden file at root",
+			path:     ".hidden",
+			patterns: []string{".*"},
+			want:     true,
+		},
+		{
+			name:     "hidden file in subdirectory",
+			path:     "dir1/.gitignore",
+			patterns: []string{".*"},
+			want:     false, // ".*" only matches files starting with . at root
+		},
+		{
+			name:     "hidden file in subdirectory with wildcard pattern",
+			path:     "dir1/.gitignore",
+			patterns: []string{"**/.*"},
+			want:     true,
+		},
+		{
+			name:     "specific directory pattern",
+			path:     "dir1/file.txt",
+			patterns: []string{"dir1/**"},
+			want:     true,
+		},
+		{
+			name:     "all txt files pattern",
+			path:     "dir1/file.txt",
+			patterns: []string{"**/*.txt"},
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsExcluded(tt.path, tt.patterns)
+			if err != nil {
+				t.Errorf("IsExcluded() error = %v", err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IsExcluded(%q, %v) = %v, want %v", tt.path, tt.patterns, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implemented parallel file system traversal to replace sequential filepath.Walk, achieving ~2x speedup in benchmarks.

## Why Not Merging

After implementation and analysis, I decided **not to merge** this because:

1. **File traversal is not the bottleneck** - It''s typically <1% of total sync time
2. **Real bottlenecks are**:
   - Network I/O for S3 operations (minutes)
   - Checksum calculations (seconds to minutes) 
   - S3 API rate limits
3. **Minimal real-world benefit** - Saves only seconds in multi-minute operations
4. **Added complexity** without proportional benefit

## Implementation Details

- Worker pool pattern with configurable workers (env: STRICT_S3_SYNC_WORKERS)
- BFS-based concurrent directory traversal
- Proper exclude pattern handling
- Comprehensive tests and benchmarks

## Benchmark Results

```
BenchmarkGatherLocalFiles_Small/Sequential-8    882      1311797 ns/op
BenchmarkGatherLocalFiles_Small/Parallel-8      1950     605994 ns/op
```

## Related

Closes #9 

The code is preserved in this PR for future reference. Other optimizations like #7 (Batch S3 API calls) and #8 (Checksum cache) would provide more significant improvements.