### PR TITLE
chore: simplify checksum filename to checksums.txt

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,7 +115,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - run: |
-          checksum=$(find dist -name "*checksums.txt")
+          checksum=$(find dist -name "checksums.txt")
           cosign sign-blob -y \
             --output-signature "${checksum}.sig" \
             --output-certificate "${checksum}.pem" \

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,7 @@ archives:
         formats: [zip]
 
 checksum:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+  name_template: "checksums.txt"
   algorithm: sha256
 
 sboms:


### PR DESCRIPTION
## Summary
- Simplified GoReleaser checksum filename from versioned format to plain `checksums.txt`
- Updated release workflow to match the new filename pattern

## Why
- Simpler and more predictable release artifact naming
- Easier integration with external tools like aqua-registry
- No need to include project name and version in checksum filename

## Changes
- `.goreleaser.yml`: Changed `name_template` from `{{ .ProjectName }}_{{ .Version }}_checksums.txt` to `checksums.txt`
- `.github/workflows/release.yaml`: Updated file pattern from `*checksums.txt` to `checksums.txt` for clarity