### PR TITLE
feat: AWS S3 sync compatible exclude patterns

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,13 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+================================================================================
+
+This software includes code derived from Python's fnmatch module.
+See pkg/fnmatch/LICENSE-PSF and pkg/fnmatch/NOTICE for details.
+
+Original Python fnmatch module:
+Copyright (c) 2001-2024 Python Software Foundation.
+All Rights Reserved.
+Licensed under the Python Software Foundation License Version 2

--- a/README.md
+++ b/README.md
@@ -169,3 +169,6 @@ Actions can be: `create`, `update`, or `delete`.
 ## License
 
 MIT
+
+This project includes code derived from Python's fnmatch module (licensed under PSF-2.0).
+See [LICENSE](LICENSE) and [pkg/fnmatch/LICENSE-PSF](pkg/fnmatch/LICENSE-PSF) for details.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.30.2
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.18.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.85.1
-	github.com/bmatcuk/doublestar/v4 v4.9.1
 	github.com/spf13/cobra v1.9.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.35.1 h1:iF4Xxkc0H9c/K2dS0zZw3SCkj0Z7
 github.com/aws/aws-sdk-go-v2/service/sts v1.35.1/go.mod h1:0bxIatfN0aLq4mjoLDeBpOjOke68OsFlXPDFJ7V0MYw=
 github.com/aws/smithy-go v1.22.5 h1:P9ATCXPMb2mPjYBgueqJNCA5S9UfktsW0tTxi+a7eqw=
 github.com/aws/smithy-go v1.22.5/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
-github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/pkg/fnmatch/LICENSE-PSF
+++ b/pkg/fnmatch/LICENSE-PSF
@@ -1,0 +1,50 @@
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+This file contains code derived from Python's fnmatch module.
+Original source: https://github.com/python/cpython/blob/main/Lib/fnmatch.py
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001-2024 Python Software Foundation; All Rights
+Reserved" are retained in Python alone or in any derivative version prepared
+by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis. PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee. This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.

--- a/pkg/fnmatch/NOTICE
+++ b/pkg/fnmatch/NOTICE
@@ -1,0 +1,25 @@
+NOTICE - Python fnmatch Module Go Port
+=======================================
+
+This package contains a Go port of Python's fnmatch module.
+
+Original Python fnmatch module:
+Copyright (c) 2001-2024 Python Software Foundation.
+All Rights Reserved.
+Source: https://github.com/python/cpython/blob/main/Lib/fnmatch.py
+Licensed under the Python Software Foundation License Version 2
+
+Go port modifications:
+Copyright (c) 2025 Yuya Takeyama
+Licensed under the MIT License
+
+Summary of changes from the original Python implementation:
+- Ported from Python to Go programming language
+- Adapted to use Go's regexp package instead of Python's re module
+- Implemented caching using sync.Map instead of Python's lru_cache
+- Removed case normalization features (fnmatch vs fnmatchcase distinction)
+- All pattern matching is case-sensitive
+- Maintained the core pattern matching behavior where * matches path separators
+
+The pattern matching behavior is intentionally kept compatible with Python's
+fnmatch module to ensure compatibility with AWS S3 sync exclude patterns.

--- a/pkg/fnmatch/fnmatch.go
+++ b/pkg/fnmatch/fnmatch.go
@@ -3,11 +3,16 @@
 // This implementation is based on Python's fnmatch module from the CPython repository.
 // Original source: https://github.com/python/cpython/blob/main/Lib/fnmatch.py
 //
+// Original Python implementation:
 // Copyright (c) 2001-2024 Python Software Foundation.
 // All Rights Reserved.
+// Licensed under the Python Software Foundation License Version 2
 //
-// This Go port is licensed under the MIT License, but includes code derived from
-// Python's fnmatch module which is licensed under the Python Software Foundation License Version 2.
+// This Go port:
+// Copyright (c) 2025 Yuya Takeyama
+// Licensed under the MIT License
+//
+// See LICENSE-PSF and NOTICE files in this directory for detailed license information.
 //
 // Patterns are Unix shell style:
 //

--- a/pkg/fnmatch/fnmatch.go
+++ b/pkg/fnmatch/fnmatch.go
@@ -1,0 +1,183 @@
+// Package fnmatch provides Unix shell style pattern matching compatible with Python's fnmatch module.
+//
+// This implementation is based on Python's fnmatch module from the CPython repository.
+// Original source: https://github.com/python/cpython/blob/main/Lib/fnmatch.py
+//
+// Copyright (c) 2001-2024 Python Software Foundation.
+// All Rights Reserved.
+//
+// This Go port is licensed under the MIT License, but includes code derived from
+// Python's fnmatch module which is licensed under the Python Software Foundation License Version 2.
+//
+// Patterns are Unix shell style:
+//
+//   - matches everything (including path separators)
+//     ?       matches any single character
+//     [seq]   matches any character in seq
+//     [!seq]  matches any character not in seq
+//
+// Unlike filesystem glob patterns, * matches path separators (like Python's fnmatch).
+// This behavior is compatible with AWS S3 sync's exclude patterns.
+package fnmatch
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// patternCache caches compiled regular expressions for performance
+var patternCache = sync.Map{}
+
+// Match tests whether name matches the shell pattern.
+// The pattern matching is case-sensitive.
+func Match(pattern, name string) (bool, error) {
+	re, err := compile(pattern)
+	if err != nil {
+		return false, err
+	}
+	return re.MatchString(name), nil
+}
+
+// compile converts a shell pattern to a compiled regular expression,
+// using a cache for performance.
+func compile(pattern string) (*regexp.Regexp, error) {
+	if cached, ok := patternCache.Load(pattern); ok {
+		return cached.(*regexp.Regexp), nil
+	}
+
+	translated := Translate(pattern)
+	re, err := regexp.Compile(translated)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile pattern %q: %w", pattern, err)
+	}
+
+	patternCache.Store(pattern, re)
+	return re, nil
+}
+
+// Translate converts a shell pattern to a regular expression string.
+// This function is exported for compatibility and testing purposes.
+func Translate(pattern string) string {
+	var result strings.Builder
+	result.WriteString("(?s:^") // (?s:...) makes . match newlines, ^ anchors to start
+
+	i := 0
+	n := len(pattern)
+
+	for i < n {
+		c := pattern[i]
+		i++
+
+		switch c {
+		case '*':
+			// Compress consecutive * into one
+			for i < n && pattern[i] == '*' {
+				i++
+			}
+			result.WriteString(".*")
+
+		case '?':
+			result.WriteByte('.')
+
+		case '[':
+			j := i
+			// Check for negation
+			if j < n && pattern[j] == '!' {
+				j++
+			}
+			// Check for closing bracket as first character
+			if j < n && pattern[j] == ']' {
+				j++
+			}
+			// Find the closing bracket
+			for j < n && pattern[j] != ']' {
+				j++
+			}
+
+			if j >= n {
+				// No closing bracket found, treat [ as literal
+				result.WriteString("\\[")
+			} else {
+				stuff := pattern[i:j]
+				i = j + 1
+
+				if len(stuff) == 0 {
+					// Empty range: never match
+					result.WriteString("(?!)")
+				} else if stuff == "!" {
+					// Negated empty range: match any character
+					result.WriteByte('.')
+				} else {
+					// Build character class
+					result.WriteByte('[')
+					if stuff[0] == '!' {
+						result.WriteByte('^')
+						stuff = stuff[1:]
+					}
+					// Escape special characters in character class
+					stuff = escapeForCharClass(stuff)
+					result.WriteString(stuff)
+					result.WriteByte(']')
+				}
+			}
+
+		default:
+			// Escape special regex characters
+			result.WriteString(regexp.QuoteMeta(string(c)))
+		}
+	}
+
+	result.WriteString("$)") // $ anchors to end
+	return result.String()
+}
+
+// escapeForCharClass escapes special characters within a character class
+func escapeForCharClass(s string) string {
+	var result strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '\\', ']':
+			result.WriteByte('\\')
+			result.WriteByte(c)
+		default:
+			// Don't escape hyphens - they're needed for ranges
+			result.WriteByte(c)
+		}
+	}
+	return result.String()
+}
+
+// Filter returns a list of names that match the pattern.
+func Filter(names []string, pattern string) ([]string, error) {
+	re, err := compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+	for _, name := range names {
+		if re.MatchString(name) {
+			result = append(result, name)
+		}
+	}
+	return result, nil
+}
+
+// FilterFalse returns a list of names that do not match the pattern.
+func FilterFalse(names []string, pattern string) ([]string, error) {
+	re, err := compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+	for _, name := range names {
+		if !re.MatchString(name) {
+			result = append(result, name)
+		}
+	}
+	return result, nil
+}

--- a/pkg/fnmatch/fnmatch_test.go
+++ b/pkg/fnmatch/fnmatch_test.go
@@ -1,0 +1,186 @@
+package fnmatch
+
+import (
+	"testing"
+)
+
+func TestMatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		input   string
+		want    bool
+	}{
+		// Basic wildcards
+		{"star matches everything", "*", "anything", true},
+		{"star matches empty", "*", "", true},
+		{"star matches path separator", "*", "path/to/file", true},
+		{"multiple stars", "**", "path/to/file", true},
+
+		// Question mark
+		{"question matches single char", "?", "a", true},
+		{"question doesn't match empty", "?", "", false},
+		{"question matches any char", "???", "abc", true},
+
+		// Path separator handling (Python fnmatch behavior)
+		{"star matches across directories", "_next/*", "_next/file.txt", true},
+		{"star matches nested directories", "_next/*", "_next/subdir/file.txt", true},
+		{"star matches deeply nested", "_next/*", "_next/subdir/deep/file.txt", true},
+
+		// Character classes
+		{"char class single", "[abc]", "a", true},
+		{"char class single", "[abc]", "b", true},
+		{"char class single", "[abc]", "d", false},
+		{"char class range", "[a-z]", "m", true},
+		{"char class range", "[a-z]", "A", false},
+		{"negated char class", "[!abc]", "d", true},
+		{"negated char class", "[!abc]", "a", false},
+
+		// Complex patterns
+		{"prefix and star", "test*", "test", true},
+		{"prefix and star", "test*", "testing", true},
+		{"prefix and star", "test*", "test/file", true},
+		{"star in middle", "test*file", "test123file", true},
+		{"star in middle with path", "test*file", "test/path/file", true},
+
+		// Real-world patterns
+		{"node_modules", "node_modules/*", "node_modules/package.json", true},
+		{"node_modules nested", "node_modules/*", "node_modules/lib/index.js", true},
+		{"git directory", ".git/*", ".git/config", true},
+		{"git objects", ".git/*", ".git/objects/abc123", true},
+		{"hidden files", ".*", ".env", true},
+		{"hidden files", ".*", ".gitignore", true},
+
+		// Extensions
+		{"all tmp files", "*.tmp", "file.tmp", true},
+		{"all tmp files", "*.tmp", "path/to/file.tmp", true},
+		{"specific extension", "*.js", "script.js", true},
+		{"specific extension", "*.js", "script.ts", false},
+
+		// Edge cases
+		{"empty pattern", "", "", true},
+		{"empty pattern no match", "", "something", false},
+		{"literal brackets", "[", "[", true},
+		{"unclosed bracket", "[abc", "[abc", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Match(tt.pattern, tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Match(%q, %q) = %v, want %v", tt.pattern, tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTranslate(t *testing.T) {
+	tests := []struct {
+		pattern  string
+		input    string
+		expected bool
+	}{
+		// Verify that translate produces valid regex
+		{"*", "anything", true},
+		{"?", "x", true},
+		{"[abc]", "b", true},
+		{"[!xyz]", "a", true},
+	}
+
+	for _, tt := range tests {
+		regex := Translate(tt.pattern)
+		t.Logf("Pattern %q translated to %q", tt.pattern, regex)
+
+		// Verify the regex compiles and works
+		got, err := Match(tt.pattern, tt.input)
+		if err != nil {
+			t.Errorf("Pattern %q failed: %v", tt.pattern, err)
+		}
+		if got != tt.expected {
+			t.Errorf("Pattern %q with input %q: got %v, want %v", tt.pattern, tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestFilter(t *testing.T) {
+	names := []string{
+		"file.txt",
+		"file.tmp",
+		"test.tmp",
+		"data.json",
+		".hidden",
+		".git/config",
+	}
+
+	tests := []struct {
+		pattern  string
+		expected []string
+	}{
+		{"*.tmp", []string{"file.tmp", "test.tmp"}},
+		{".*", []string{".hidden", ".git/config"}},
+		{"*", names},          // all files
+		{"?.txt", []string{}}, // no single char .txt files
+		{"file.*", []string{"file.txt", "file.tmp"}},
+	}
+
+	for _, tt := range tests {
+		got, err := Filter(names, tt.pattern)
+		if err != nil {
+			t.Fatalf("Filter error: %v", err)
+		}
+
+		if len(got) != len(tt.expected) {
+			t.Errorf("Filter(%q): got %v, want %v", tt.pattern, got, tt.expected)
+			continue
+		}
+
+		for i, name := range got {
+			if name != tt.expected[i] {
+				t.Errorf("Filter(%q): got %v, want %v", tt.pattern, got, tt.expected)
+				break
+			}
+		}
+	}
+}
+
+func TestFilterFalse(t *testing.T) {
+	names := []string{
+		"file.txt",
+		"file.tmp",
+		"test.tmp",
+	}
+
+	got, err := FilterFalse(names, "*.tmp")
+	if err != nil {
+		t.Fatalf("FilterFalse error: %v", err)
+	}
+
+	expected := []string{"file.txt"}
+	if len(got) != 1 || got[0] != expected[0] {
+		t.Errorf("FilterFalse: got %v, want %v", got, expected)
+	}
+}
+
+// Benchmark to ensure performance with cache
+func BenchmarkMatch(b *testing.B) {
+	pattern := "node_modules/*"
+	name := "node_modules/package.json"
+
+	for i := 0; i < b.N; i++ {
+		_, _ = Match(pattern, name)
+	}
+}
+
+func BenchmarkMatchNoCache(b *testing.B) {
+	name := "node_modules/package.json"
+
+	for i := 0; i < b.N; i++ {
+		pattern := "node_modules/*"
+		// Clear cache to simulate no caching
+		patternCache.Delete(pattern)
+		_, _ = Match(pattern, name)
+	}
+}

--- a/pkg/planner/pure_functions.go
+++ b/pkg/planner/pure_functions.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/bmatcuk/doublestar/v4"
+	"github.com/yuya-takeyama/strict-s3-sync/pkg/fnmatch"
 )
 
 func Phase1Compare(source []ItemMetadata, dest []ItemMetadata, deleteEnabled bool) Phase1Result {
@@ -143,7 +143,7 @@ func sortPhase1Result(result *Phase1Result) {
 
 func IsExcluded(path string, patterns []string) (bool, error) {
 	for _, pattern := range patterns {
-		matched, err := doublestar.Match(pattern, path)
+		matched, err := fnmatch.Match(pattern, path)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/planner/pure_functions_test.go
+++ b/pkg/planner/pure_functions_test.go
@@ -394,14 +394,14 @@ func TestIsExcluded(t *testing.T) {
 		{
 			name:     "directory match",
 			path:     "node_modules/package.json",
-			patterns: []string{"node_modules/**"},
+			patterns: []string{"node_modules/*"},
 			want:     true,
 			wantErr:  false,
 		},
 		{
 			name:     "nested directory match",
 			path:     "src/test/data.tmp",
-			patterns: []string{"**/*.tmp"},
+			patterns: []string{"*.tmp"},
 			want:     true,
 			wantErr:  false,
 		},
@@ -426,11 +426,26 @@ func TestIsExcluded(t *testing.T) {
 			want:     true,
 			wantErr:  false,
 		},
+		// AWS S3 sync compatible behavior tests
+		{
+			name:     "aws compat: star matches across directories",
+			path:     "_next/subdir/file.txt",
+			patterns: []string{"_next/*"},
+			want:     true, // With fnmatch, * matches path separators
+			wantErr:  false,
+		},
+		{
+			name:     "aws compat: deeply nested match",
+			path:     "_next/subdir/deep/file.txt",
+			patterns: []string{"_next/*"},
+			want:     true, // With fnmatch, * matches path separators
+			wantErr:  false,
+		},
 		{
 			name:     "complex pattern",
 			path:     "src/components/Button.test.tsx",
-			patterns: []string{"**/*.test.*"},
-			want:     true,
+			patterns: []string{"*.test.*"},
+			want:     true, // With fnmatch, * matches path separators
 			wantErr:  false,
 		},
 		{
@@ -443,7 +458,7 @@ func TestIsExcluded(t *testing.T) {
 		{
 			name:     "hidden files",
 			path:     ".git/config",
-			patterns: []string{".git/**"},
+			patterns: []string{".git/*"},
 			want:     true,
 			wantErr:  false,
 		},


### PR DESCRIPTION
## Summary
- Replace doublestar with Python fnmatch for AWS S3 sync compatibility
- `*` now matches path separators, matching AWS CLI behavior
- Add proper PSF-2.0 license attribution for ported code

## Details

### Problem
The current exclude pattern implementation using doublestar follows standard Unix glob behavior where `*` does not match path separators. This differs from AWS S3 sync which uses Python fnmatch where `*` matches everything including `/`.

For example:
- **Before (doublestar)**: `--exclude "_next/*"` only excludes `_next/file.txt`
- **After (fnmatch)**: `--exclude "_next/*"` excludes `_next/file.txt`, `_next/subdir/file.txt`, etc.

### Solution
Ported Python fnmatch module to Go, maintaining the exact pattern matching behavior for AWS S3 sync compatibility.

### Changes
1. **New fnmatch package**: Go port of Python fnmatch with proper PSF-2.0 license attribution
2. **Pattern matching update**: Replace doublestar.Match with fnmatch.Match
3. **Test updates**: Verify AWS S3 sync compatible behavior
4. **License compliance**: Add LICENSE-PSF and NOTICE files with proper attribution

## Breaking Change
⚠️ This changes exclude pattern behavior to match AWS S3 sync. Patterns with `*` now match across directory boundaries.

## Test plan
- [x] Unit tests for fnmatch package
- [x] Integration tests for exclude patterns
- [x] Verify AWS S3 sync compatibility
- [ ] Manual testing with real S3 buckets

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>