### PR TITLE
refactor: rename "action" to "result" field in result JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,22 +147,22 @@ Outputs actual execution results (not generated in dry-run mode):
 {
   "files": [
     {
-      "action": "created",
+      "result": "created",
       "source": "/Users/yuya/project/file1.txt",
       "target": "s3://my-bucket/prefix/file1.txt"
     },
     {
-      "action": "updated",
+      "result": "updated",
       "source": "/Users/yuya/project/file2.txt",
       "target": "s3://my-bucket/prefix/file2.txt"
     },
     {
-      "action": "skipped",
+      "result": "skipped",
       "source": "/Users/yuya/project/file3.txt",
       "target": "s3://my-bucket/prefix/file3.txt"
     },
     {
-      "action": "deleted",
+      "result": "deleted",
       "target": "s3://my-bucket/prefix/old-file.txt"
     }
   ],
@@ -177,7 +177,7 @@ Outputs actual execution results (not generated in dry-run mode):
 }
 ```
 
-Result actions: `skipped`, `created`, `updated`, `deleted` (past tense)
+Result values: `skipped`, `created`, `updated`, `deleted` (past tense)
 
 Failed operations appear in the `errors` array with error messages.
 

--- a/cmd/strict-s3-sync/main.go
+++ b/cmd/strict-s3-sync/main.go
@@ -65,7 +65,7 @@ type SyncResult struct {
 }
 
 type ResultFile struct {
-	Action string `json:"action"` // "skipped", "created", "updated", "deleted"
+	Result string `json:"result"` // "skipped", "created", "updated", "deleted"
 	Source string `json:"source,omitempty"`
 	Target string `json:"target"`
 }
@@ -248,21 +248,21 @@ func run(cmd *cobra.Command, args []string) error {
 					syncResult.Summary.Updated++
 				}
 				file := ResultFile{
-					Action: actionPast,
+					Result: actionPast,
 					Source: getAbsolutePath(result.Item.LocalPath),
 					Target: formatS3Path(result.Item.Bucket, result.Item.Key),
 				}
 				syncResult.Files = append(syncResult.Files, file)
 			case planner.ActionDelete:
 				file := ResultFile{
-					Action: "deleted",
+					Result: "deleted",
 					Target: formatS3Path(result.Item.Bucket, result.Item.Key),
 				}
 				syncResult.Files = append(syncResult.Files, file)
 				syncResult.Summary.Deleted++
 			case planner.ActionSkip:
 				file := ResultFile{
-					Action: "skipped",
+					Result: "skipped",
 					Source: getAbsolutePath(result.Item.LocalPath),
 					Target: formatS3Path(result.Item.Bucket, result.Item.Key),
 				}


### PR DESCRIPTION
## Summary

Renamed the field name in result JSON from `"action"` to `"result"` for better semantic clarity.

## Why?

The field name `"action"` in the result JSON was confusing because:
- An action is something you plan to do (future/present)
- A result is the outcome of what was done (past)

This change makes the distinction clearer:
- **Plan JSON**: Uses `"action"` field → what will be done (`"create"`, `"update"`, `"delete"`, `"skip"`)
- **Result JSON**: Uses `"result"` field → what was done (`"created"`, `"updated"`, `"deleted"`, `"skipped"`)

## Changes

### Before
```json
{
  "files": [
    {
      "action": "created",
      "source": "/path/to/file.txt",
      "target": "s3://bucket/file.txt"
    }
  ]
}
```

### After
```json
{
  "files": [
    {
      "result": "created",
      "source": "/path/to/file.txt",
      "target": "s3://bucket/file.txt"
    }
  ]
}
```

## Impact

- **Breaking Change**: Yes, this changes the JSON output structure
- **Migration**: Users parsing result JSON will need to update from `action` to `result` field

## Testing

- [x] Build successful
- [x] All tests pass
- [x] Manual testing with real S3 bucket confirmed correct JSON output

🤖 Generated with [Claude Code](https://claude.ai/code)